### PR TITLE
Use ERC20Upgradeable to initialize token name and symbol

### DIFF
--- a/script/DeployScript.s.sol
+++ b/script/DeployScript.s.sol
@@ -46,6 +46,9 @@ contract DeployScript is Script {
         // wrap in ABI to support easier calls
         SUPTB wrappedToken = SUPTB(address(tokenProxy));
 
+        // initialize token contract
+        wrappedToken.initialize("Superstate Short-Term Government Securities Fund", "SUPTB");
+
         vm.stopBroadcast();
     }
 }

--- a/src/SUPTB.sol
+++ b/src/SUPTB.sol
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity ^0.8.20;
 
-import { ERC20 } from "openzeppelin-contracts/token/ERC20/ERC20.sol";
-import { Pausable } from "openzeppelin-contracts/security/Pausable.sol";
+import { ERC20Upgradeable } from "openzeppelin-contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { PausableUpgradeable } from "openzeppelin-contracts-upgradeable/security/PausableUpgradeable.sol";
 import { ECDSA } from "openzeppelin-contracts/utils/cryptography/ECDSA.sol";
 
 import { IERC7246 } from "src/interfaces/IERC7246.sol";
@@ -14,7 +14,7 @@ import { PermissionList } from "src/PermissionList.sol";
  * @notice A Pausable ERC7246 token contract that interacts with the PermissionList contract to check if transfers are allowed
  * @author Compound
  */
-contract SUPTB is ERC20, IERC7246, Pausable {
+contract SUPTB is ERC20Upgradeable, IERC7246, PausableUpgradeable {
     /// @notice The major version of this contract
     string public constant VERSION = "1";
 
@@ -75,10 +75,22 @@ contract SUPTB is ERC20, IERC7246, Pausable {
      * @notice Construct a new ERC20 token instance with the given admin and PermissionList
      * @param _admin The address designated as the admin with special privileges
      * @param _permissionList Address of the PermissionList contract to use for permission checking
+     * @dev Disables initialization on the implementation contract
      */
-    constructor(address _admin, PermissionList _permissionList) ERC20("Superstate Treasuries Blockchain", "SUPTB") {
+    constructor(address _admin, PermissionList _permissionList) {
         admin = _admin;
         permissionList = _permissionList;
+
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initialize the contract
+     * @param _name The token name
+     * @param _symbol The token symbol
+     */
+    function initialize(string calldata _name, string calldata _symbol) initializer public {
+        __ERC20_init(_name, _symbol);
     }
 
     /**


### PR DESCRIPTION
The previous implementation of `SUPTB` was setting the token `name` and `symbol` in the storage of the implementation contract, so they couldn't be accessed in the proxy.

This PR updates the contract to extend `ERC20Upgradeable` instead of `ERC20` in order to initialize `name` and `symbol` in the proxy using the `initialize` function. 

An alternative approach would be to set the `name` and `description` as immutables in the constructor, but these values would need to be defined as `byte32`'s instead of strings. This is quite limiting, given the fact that the token name could potentially be much longer than 32 characters.