### PR TITLE
Initialize PausableUpgradeable

### DIFF
--- a/src/SUPTB.sol
+++ b/src/SUPTB.sol
@@ -90,6 +90,7 @@ contract SUPTB is ERC20Upgradeable, IERC7246, PausableUpgradeable {
      */
     function initialize(string calldata _name, string calldata _symbol) initializer public {
         __ERC20_init(_name, _symbol);
+        __Pausable_init();
     }
 
     /**

--- a/test/SUPTB.t.sol
+++ b/test/SUPTB.t.sol
@@ -78,6 +78,10 @@ contract SUPTBTest is Test {
         assertEq(token.decimals(), 6);
     }
 
+    function testTokenIsInitializedAsUnpaused() public {
+        assertEq(token.paused(), false);
+    }
+
     function testInitializeRevertIfCalledAgain() public {
         vm.expectRevert(bytes("Initializable: contract is already initialized"));
         token.initialize("new name", "new symbol");


### PR DESCRIPTION
Addresses 7.4 of the ChainSecurity audit. Even though this function call is unnecessary (it just initializes `paused` to false, which it already is by default), we add it to conform with best practices.