### PR TITLE
Pausable changes

### DIFF
--- a/src/SUPTB.sol
+++ b/src/SUPTB.sol
@@ -79,8 +79,11 @@ contract SUPTB is ERC20Upgradeable, IERC7246, PausableUpgradeable {
     /// @dev Thrown if the signature is invalid or its signer does not match the expected singer
     error BadSignatory();
 
-    /// @dev Thrown if action is in the wrong pause state
-    error WrongPausedState();
+    /// @dev Thrown if accounting pause is already on
+    error AccountingIsPaused();
+
+    /// @dev Thrown if accounting pause is already off
+    error AccountingIsNotPaused();
 
     /**
      * @notice Construct a new ERC20 token instance with the given admin and PermissionList
@@ -106,7 +109,7 @@ contract SUPTB is ERC20Upgradeable, IERC7246, PausableUpgradeable {
     }
 
     function _requireNotAccountingPaused() internal view {
-        if (accountingPaused) revert WrongPausedState();
+        if (accountingPaused) revert AccountingIsPaused();
     }
 
     /**
@@ -149,7 +152,7 @@ contract SUPTB is ERC20Upgradeable, IERC7246, PausableUpgradeable {
      */
     function accountingUnpause() external {
         if (msg.sender != admin) revert Unauthorized();
-        if (!accountingPaused) revert WrongPausedState();
+        if (!accountingPaused) revert AccountingIsNotPaused();
 
         accountingPaused = false;
         emit AccountingUnpaused(msg.sender);

--- a/test/SUPTB.t.sol
+++ b/test/SUPTB.t.sol
@@ -789,7 +789,7 @@ contract SUPTBTest is Test {
     // cannot double set any pause
     function testCannotDoublePause() public {
         token.accountingPause();
-        vm.expectRevert(SUPTB.WrongPausedState.selector);
+        vm.expectRevert(SUPTB.AccountingIsPaused.selector);
         token.accountingPause();
 
         token.pause();
@@ -801,7 +801,7 @@ contract SUPTBTest is Test {
         token.accountingPause();
 
         token.accountingUnpause();
-        vm.expectRevert(SUPTB.WrongPausedState.selector);
+        vm.expectRevert(SUPTB.AccountingIsNotPaused.selector);
         token.accountingUnpause();
 
         token.pause();
@@ -824,18 +824,18 @@ contract SUPTBTest is Test {
 
         assertEq(token.balanceOf(alice), 100e6);
 
-        vm.expectRevert(SUPTB.WrongPausedState.selector);
+        vm.expectRevert(SUPTB.AccountingIsPaused.selector);
         token.mint(alice, 100e6);
 
-        vm.expectRevert(SUPTB.WrongPausedState.selector);
+        vm.expectRevert(SUPTB.AccountingIsPaused.selector);
         token.burn(alice, 100e6);
 
         vm.prank(alice);
-        vm.expectRevert(SUPTB.WrongPausedState.selector);
+        vm.expectRevert(SUPTB.AccountingIsPaused.selector);
         token.transfer(address(0), 50e6);
 
         vm.prank(alice);
-        vm.expectRevert(SUPTB.WrongPausedState.selector);
+        vm.expectRevert(SUPTB.AccountingIsPaused.selector);
         token.transferFrom(alice, address(0), 50e6);
 
         token.accountingUnpause();


### PR DESCRIPTION
closes https://github.com/superstateinc/webserver/issues/65

adds one pausable toggle for for transfer/transferfrom, encumber/encumberFrom
adds a seperate one for minting / burning
release is no longer pausable