### PR TITLE
chore: adds storage tests for upgrade

### DIFF
--- a/src/SuperstateToken.sol
+++ b/src/SuperstateToken.sol
@@ -22,6 +22,12 @@ abstract contract SuperstateToken is
     PausableUpgradeable,
     Ownable2StepUpgradeable
 {
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to inherit from new contracts
+     * without impacting the fields within `SuperstateToken`.
+     */
+    uint256[500] private __inheritanceGap;
+
     /// @notice The major version of this contract
     string public constant VERSION = "2";
 
@@ -54,6 +60,12 @@ abstract contract SuperstateToken is
 
     /// @notice Number of decimals used for the user representation of the token
     uint8 private constant DECIMALS = 6;
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new fields without impacting
+     * any contracts that inherit `SuperstateToken`
+     */
+    uint256[100] private __additionalFieldsGap;
 
     /**
      * @notice Construct a new ERC20 token instance with the given admin and AllowList

--- a/src/interfaces/ISuperstateToken.sol
+++ b/src/interfaces/ISuperstateToken.sol
@@ -83,6 +83,11 @@ interface ISuperstateToken is IERC20Upgradeable, IERC7246 {
     function unpause() external;
 
     /**
+     * @return bool True if the accounting is currently paused, false otherwise
+     */
+    function accountingPaused() external view returns (bool);
+
+    /**
      * @notice Pauses mint and burn
      * @dev Can only be called by the admin
      */

--- a/test/AllowList.t.sol
+++ b/test/AllowList.t.sol
@@ -38,7 +38,7 @@ contract AllowListTest is Test {
 
         // deploy proxy contract and point it to implementation
         proxy = new TransparentUpgradeableProxy(address(permsImplementation), address(this), "");
-        proxyAdmin =  ProxyAdmin(getAdminAddress(address(proxy)));
+        proxyAdmin = ProxyAdmin(getAdminAddress(address(proxy)));
 
         // wrap in ABI to support easier calls
         perms = AllowList(address(proxy));

--- a/test/SuperstateTokenStorageLayoutTestBase.t.sol
+++ b/test/SuperstateTokenStorageLayoutTestBase.t.sol
@@ -253,3 +253,30 @@ abstract contract SuperstateTokenStorageLayoutTestBase is Test {
         return string(bytesArray);
     }
 }
+
+contract A {
+    uint256 public a;
+}
+
+contract B {
+    uint256 public b;
+}
+
+contract TokenV1 is A {
+    uint256 public c;
+}
+
+contract TokenV2 is A, B {
+    uint256 public c;
+}
+
+/*
+    V1 Storage:
+    Slot 0: a
+    Slot 1: c
+
+    V2 Storage:
+    Slot 0: a
+    Slot 1: b (corruption)
+    Slot 2: c
+*/

--- a/test/SuperstateTokenStorageLayoutTestBase.t.sol
+++ b/test/SuperstateTokenStorageLayoutTestBase.t.sol
@@ -1,0 +1,255 @@
+pragma solidity ^0.8.28;
+
+import "forge-std/StdUtils.sol";
+import {Test} from "forge-std/Test.sol";
+
+import "openzeppelin-contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "openzeppelin-contracts/proxy/transparent/ProxyAdmin.sol";
+
+import {SuperstateTokenV1} from "src/v1/SuperstateTokenV1.sol";
+import {ISuperstateToken} from "src/interfaces/ISuperstateToken.sol";
+import {USTBv1} from "src/v1/USTBv1.sol";
+import {AllowList} from "src/AllowList.sol";
+import "test/AllowListV2.sol";
+import "test/USTBV2.sol";
+
+/**
+ * Superstate Token storage layout:
+ *
+ *  Slot 51: ERC20Upgradeable._balances
+ *  Slot 52: Erc20Upgradeable._allowances
+ *  Slot 53: Erc20Upgradeable._totalSupply
+ *  Slot 54: Erc20Upgradeable._name
+ *  Slot 55: Erc20Upgradeable._symbol
+ *  Slot 101: PausableUpgradeable._paused
+ *  Slot 151: SuperstateToken.nonces
+ *  Slot 152: SuperstateToken.encumberedBalanceOf
+ *  Slot 153: SuperstateToken.encumbrances
+ *  Slot 154: SuperstateToken.accountingPaused
+ */
+abstract contract SuperstateTokenStorageLayoutTestBase is Test {
+    ProxyAdmin public proxyAdmin;
+    TransparentUpgradeableProxy public permsProxy;
+    AllowList public perms;
+    TransparentUpgradeableProxy public tokenProxy;
+
+    ISuperstateToken public oldToken;
+    ISuperstateToken public newToken;
+    ISuperstateToken public currentToken;
+
+    string public oldTokenVersion;
+    string public newTokenVersion;
+
+    address public alice = address(10);
+    address public bob = address(11);
+    address public charlie = address(12);
+    address public mallory = address(13);
+
+    uint256 public abcEntityId = 1;
+
+    function setUp() public virtual {
+        AllowList permsImplementation = new AllowList(address(this));
+
+        // deploy proxy admin contract
+        proxyAdmin = new ProxyAdmin();
+
+        // deploy proxy contract and point it to implementation
+        permsProxy = new TransparentUpgradeableProxy(address(permsImplementation), address(proxyAdmin), "");
+
+        // wrap in ABI to support easier calls
+        perms = AllowList(address(permsProxy));
+
+        initializeExpectedTokenVersions();
+        initializeOldToken();
+
+        // whitelist alice bob, and charlie (so they can tranfer to each other), but not mallory
+        AllowList.Permission memory allowPerms = AllowList.Permission(true, false, false, false, false, false);
+
+        perms.setEntityIdForAddress(abcEntityId, alice);
+        perms.setEntityIdForAddress(abcEntityId, bob);
+        address[] memory addrs = new address[](1);
+        addrs[0] = charlie;
+        perms.setEntityPermissionAndAddresses(abcEntityId, addrs, allowPerms);
+    }
+
+    function initializeExpectedTokenVersions() public virtual;
+
+    function initializeOldToken() public virtual;
+
+    function upgradeAndInitializeNewToken() public virtual;
+
+    function manipulateStateOldToken() public {
+        // availableBalanceOf is 0 by default
+        assertEq(oldToken.availableBalanceOf(alice), 0);
+
+        // mint some to alice
+        currentToken.mint(alice, 100e6);
+
+        // reflects balance when there are no encumbrances
+        vm.startPrank(alice);
+        assertEq(oldToken.balanceOf(alice), 100e6);
+        assertEq(oldToken.availableBalanceOf(alice), 100e6);
+
+        // is reduced by encumbrances
+        oldToken.encumber(bob, 20e6);
+        assertEq(oldToken.balanceOf(alice), 100e6);
+        assertEq(oldToken.availableBalanceOf(alice), 80e6);
+
+        // is reduced by transfers
+        oldToken.transfer(bob, 20e6);
+        assertEq(oldToken.balanceOf(alice), 80e6);
+        assertEq(oldToken.availableBalanceOf(alice), 60e6);
+
+        vm.stopPrank();
+
+        vm.startPrank(bob);
+
+        // is NOT reduced by transferFrom (from an encumbered address)
+        oldToken.transferFrom(alice, charlie, 10e6);
+        assertEq(oldToken.balanceOf(alice), 70e6);
+        assertEq(oldToken.availableBalanceOf(alice), 60e6);
+        assertEq(oldToken.encumbrances(alice, bob), 10e6);
+        assertEq(oldToken.balanceOf(charlie), 10e6);
+
+        // is increased by a release
+        oldToken.release(alice, 5e6);
+        assertEq(oldToken.balanceOf(alice), 70e6);
+        assertEq(oldToken.availableBalanceOf(alice), 65e6);
+        assertEq(oldToken.encumbrances(alice, bob), 5e6);
+
+        vm.stopPrank();
+
+        currentToken.pause();
+        currentToken.accountingPause();
+    }
+
+    function loadSlot(uint256 slot) public view returns (bytes32) {
+        return vm.load(address(tokenProxy), bytes32(slot));
+    }
+
+    function assertStorageLayout() public {
+        assertSuperstateTokenStorageLayout();
+        assertErc20UpgradeableStorageLayout();
+        assertPausableUpgradeableStorageLayout();
+        assertOwnable2StepUpgradeableStorageLayout();
+    }
+
+    function assertSuperstateTokenStorageLayout() public {
+        /*
+            Note - the following variables are not stored in contract storage, but are rather in-lined
+            in the contract's bytecode as a compiler optimization:
+                > VERSION
+                > AUTHORIZATION_TYPEHASH
+                > DOMAIN_TYPEHASH
+                > _deprecatedAdmin
+        */
+
+        // assert nonces
+
+        // assert encumberedBalanceOf (stored in storage slot 152)
+        bytes32 encumberedBalanceOfSlot = keccak256(abi.encode(alice, uint256(152)));
+        uint256 encumberedBalanceOfSlotValue = uint256(vm.load(address(tokenProxy), encumberedBalanceOfSlot));
+        uint256 expectedAliceEncumberedBalanceOf = 5e6;
+        assertEq(encumberedBalanceOfSlotValue, expectedAliceEncumberedBalanceOf);
+
+        // assert encumberedBalanceOf from contract method
+        assertEq(currentToken.encumberedBalanceOf(alice), expectedAliceEncumberedBalanceOf);
+
+        // assert encumbrances (stored in storage slot 153).
+        bytes32 encumberancesOwnerSlot = keccak256(abi.encode(alice, uint256(153)));
+        bytes32 encumberancesTakerSlot = keccak256(abi.encode(bob, uint256(encumberancesOwnerSlot)));
+        uint256 encumberancesTakerSlotValue = uint256(vm.load(address(tokenProxy), encumberancesTakerSlot));
+        assertEq(encumberancesTakerSlotValue, expectedAliceEncumberedBalanceOf);
+
+        // assert encumbrances from contract method
+        assertEq(currentToken.encumbrances(alice, bob), expectedAliceEncumberedBalanceOf);
+
+        // assert accountingPaused (storage slot 154)
+        uint256 accountingPausedSlotValue = uint256(loadSlot(154));
+        assertEq(1, accountingPausedSlotValue);
+
+        // assert accountingPaused from contract method
+        assertEq(true, currentToken.accountingPaused());
+
+        // assert decimals
+    }
+
+    function assertErc20UpgradeableStorageLayout() public {
+        // assert balances storage slot (stored in storage slot 51)
+        bytes32 balanceSlot = keccak256(abi.encode(alice, uint256(51)));
+        uint256 balanceSlotValue = uint256(vm.load(address(tokenProxy), balanceSlot));
+        uint256 expectedAliceBalance = 70e6;
+        assertEq(balanceSlotValue, expectedAliceBalance);
+
+        // assert balances from contract method
+        assertEq(currentToken.balanceOf(alice), expectedAliceBalance);
+
+        // assert name slot (stored in storage slot 54)
+        // note: this is complex due to how strings are stored in solidity. they are dynamic and can potentially take up more than one slot,
+        // and so we need to read a pointer to its actual memory location
+        uint256 nameSlotData = uint256(keccak256(abi.encode(bytes32(uint256(54)))));
+
+        bytes memory storedData = new bytes(64);
+        for (uint256 i = 0; i < storedData.length / 32; i++) {
+            bytes32 chunk = loadSlot(nameSlotData + i);
+            for (uint256 j = 0; j < 32; j++) {
+                storedData[i * 32 + j] = chunk[j];
+            }
+        }
+        bytes memory cleanedStoredData = new bytes(55); // name is 55 bytes
+        for (uint256 i = 0; i < cleanedStoredData.length; i++) {
+            cleanedStoredData[i] = storedData[i];
+        }
+        string memory nameSlotValue = string(cleanedStoredData);
+
+        assertEq("Superstate Short Duration US Government Securities Fund", nameSlotValue);
+
+        // assert name slot from contract method
+        assertEq(
+            "Superstate Short Duration US Government Securities Fund", SuperstateTokenV1(address(tokenProxy)).name()
+        );
+
+        // assert symbol slot (stored in storage slot 55)
+        // note: ths is simpler than `name` because the value is small and be stored in a single 32 byte slot.
+        bytes32 symbolSlot = loadSlot(55);
+        assertEq("USTB", bytes32ToString(symbolSlot));
+
+        // assert symbol slot from contract method
+        assertEq("USTB", SuperstateTokenV1(address(tokenProxy)).symbol());
+    }
+
+    function assertPausableUpgradeableStorageLayout() public {
+        // assert _paused stora slot (stored in stora slot 101)
+        uint256 pausedSlotValue = uint256(loadSlot(101));
+        assertEq(1, pausedSlotValue);
+    }
+
+    function assertOwnable2StepUpgradeableStorageLayout() public {}
+
+    function testUpgradeStorageLayout() public {
+        // do some state manipulation
+        manipulateStateOldToken();
+
+        // assert storage layout
+        assertStorageLayout();
+
+        // upgrade to newToken
+        upgradeAndInitializeNewToken();
+
+        // assert storage layout
+        assertStorageLayout();
+    }
+
+    // Helper function to convert bytes32 to a string
+    function bytes32ToString(bytes32 _bytes32) internal pure returns (string memory) {
+        uint8 i = 0;
+        while (i < 32 && _bytes32[i] != 0) {
+            i++;
+        }
+        bytes memory bytesArray = new bytes(i);
+        for (i = 0; i < 32 && _bytes32[i] != 0; i++) {
+            bytesArray[i] = _bytes32[i];
+        }
+        return string(bytesArray);
+    }
+}

--- a/test/SuperstateTokenTestBase.t.sol
+++ b/test/SuperstateTokenTestBase.t.sol
@@ -85,11 +85,11 @@ contract SuperstateTokenTestBase is Test {
     }
 
     function testTokenDecimals() public {
-        //        assertEq(token.decimals(), 6);
+        assertEq(SuperstateTokenV1(address(token)).decimals(), 6);
     }
 
     function testTokenIsInitializedAsUnpaused() public {
-        //        assertEq(token.paused(), false);
+        assertEq(SuperstateTokenV1(address(token)).paused(), false);
     }
 
     function testInitializeRevertIfCalledAgain() public {

--- a/test/TokenTestBase.t.sol
+++ b/test/TokenTestBase.t.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.8.28;
+
+import "forge-std/StdUtils.sol";
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+import "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Utils.sol";
+
+contract TokenTestBase is Test {
+    function getAdminAddress(address _proxy) internal view returns (address) {
+        address CHEATCODE_ADDRESS = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
+        Vm vm = Vm(CHEATCODE_ADDRESS);
+
+        bytes32 adminSlot = vm.load(_proxy, ERC1967Utils.ADMIN_SLOT);
+        return address(uint160(uint256(adminSlot)));
+    }
+}

--- a/test/v1/USCCv1.t.sol
+++ b/test/v1/USCCv1.t.sol
@@ -106,7 +106,9 @@ contract USCCv1Test is SuperstateTokenTestBase {
 
     function testUpgradingAllowListDoesNotAffectToken() public override {
         AllowListV2 permsV2Implementation = new AllowListV2(address(this));
-        permsProxyAdmin.upgradeAndCall(ITransparentUpgradeableProxy(address(permsProxy)), address(permsV2Implementation), "");
+        permsProxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(address(permsProxy)), address(permsV2Implementation), ""
+        );
 
         AllowListV2 permsV2 = AllowListV2(address(permsProxy));
 
@@ -146,11 +148,15 @@ contract USCCv1Test is SuperstateTokenTestBase {
 
     function testUpgradingAllowListAndTokenWorks() public override {
         AllowListV2 permsV2Implementation = new AllowListV2(address(this));
-        permsProxyAdmin.upgradeAndCall(ITransparentUpgradeableProxy(address(permsProxy)), address(permsV2Implementation), "");
+        permsProxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(address(permsProxy)), address(permsV2Implementation), ""
+        );
         AllowListV2 permsV2 = AllowListV2(address(permsProxy));
 
         USCCV2 tokenV2Implementation = new USCCV2(address(this), permsV2);
-        tokenProxyAdmin.upgradeAndCall(ITransparentUpgradeableProxy(address(tokenProxy)), address(tokenV2Implementation), "");
+        tokenProxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(address(tokenProxy)), address(tokenV2Implementation), ""
+        );
         USCCV2 tokenV2 = USCCV2(address(tokenProxy));
 
         // Whitelisting criteria now requires `state7` (newly added state) be true,
@@ -231,8 +237,9 @@ contract USCCv1Test is SuperstateTokenTestBase {
         vm.assume(recipient != address(0) && recipient2 != address(0));
         // proxy admin cant use protocol
         vm.assume(
-            address(permsProxyAdmin) != spender && address(permsProxyAdmin) != recipient && address(permsProxyAdmin) != recipient2 &&
-            address(tokenProxyAdmin) != spender && address(tokenProxyAdmin) != recipient && address(tokenProxyAdmin) != recipient2
+            address(permsProxyAdmin) != spender && address(permsProxyAdmin) != recipient
+                && address(permsProxyAdmin) != recipient2 && address(tokenProxyAdmin) != spender
+                && address(tokenProxyAdmin) != recipient && address(tokenProxyAdmin) != recipient2
         );
 
         // whitelist spender and recipients

--- a/test/v1/USTBv1.t.sol
+++ b/test/v1/USTBv1.t.sol
@@ -2,6 +2,6 @@ pragma solidity ^0.8.28;
 
 import "forge-std/StdUtils.sol";
 import {Test} from "forge-std/Test.sol";
-import {SuperstateTokenTestBase} from "test/SuperstateTokenTestBase.t.sol";
+import "test/SuperstateTokenTestBase.t.sol";
 
 contract USTBv1Test is SuperstateTokenTestBase {}

--- a/test/v2/ExampleTokenUpgradeStorageLayoutTests.t.sol
+++ b/test/v2/ExampleTokenUpgradeStorageLayoutTests.t.sol
@@ -1,0 +1,176 @@
+pragma solidity ^0.8.28;
+
+import "forge-std/StdUtils.sol";
+import {Test} from "forge-std/Test.sol";
+import {console} from "forge-std/console.sol";
+
+import "openzeppelin-contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "openzeppelin-contracts/proxy/transparent/ProxyAdmin.sol";
+
+/*
+* This test shows that we can safely upgrade from SuperstateTokenV1 to SuperstateTokenV2
+* Steps we'll need to do:
+*   > Add __gap at the beginning of `SuperstateToken`
+*   > Add __gap2 at the end of `SuperstateToken`
+*   > Optionally remove `encumberedBalanceOf`, `encumberances` as they have not been used in v1 and thus will not have corrupt storage
+*/
+contract ExampleTokenUpgradeStorageLayoutTests is Test {
+    TransparentUpgradeableProxy tokenProxy;
+
+    function setUp() public {}
+
+    function loadSlot(uint256 slot) public view returns (bytes32) {
+        return vm.load(address(tokenProxy), bytes32(slot));
+    }
+
+    function testExampleUpgradeStorageLayout() public {
+        assertEq(true, true);
+        console.log("hi");
+
+        // create TokenV1 and proxies
+        TokenV1 tokenV1Impl = new TokenV1();
+
+        ProxyAdmin proxyAdmin = new ProxyAdmin();
+        tokenProxy = new TransparentUpgradeableProxy(address(tokenV1Impl), address(proxyAdmin), "");
+        TokenV1 tokenV1 = TokenV1(address(tokenProxy));
+
+        // init TokenV1
+        tokenV1.init();
+
+        // assert storage
+        uint256 expectedA = 1;
+        assertEq(expectedA, uint256(loadSlot(0))); // a
+        assertEq(expectedA, tokenV1.a());
+
+        uint256 expectedTV1Unused = 0;
+        assertEq(expectedTV1Unused, uint256(loadSlot(1))); // tV1_unused
+        assertEq(expectedTV1Unused, tokenV1.tV1_unused());
+
+        // create TokenV2 and update proxy
+        TokenV2 tokenV2Impl = new TokenV2();
+        proxyAdmin.upgrade(ITransparentUpgradeableProxy(address(tokenProxy)), address(tokenV2Impl));
+        TokenV2 tokenV2 = TokenV2(address(tokenProxy));
+
+        // init TokenV2
+        tokenV2.initV2(); // overwrites tV1_unused w/ b
+
+        // assert storage
+        assertEq(expectedA, uint256(loadSlot(0))); // a, storage preserved
+
+        uint256 expectedB = 2;
+        assertEq(expectedB, uint256(loadSlot(1))); // b, overwrote tV1_unused
+        assertEq(expectedB, tokenV2.b());
+
+        for (uint256 i = 2; i < 50; i++) {
+            assertEq(0, uint256(loadSlot(i))); // empty gap
+        }
+
+        uint256 expectedTV2 = 3;
+        assertEq(expectedTV2, uint256(loadSlot(51))); // tV2, past the __gap
+        assertEq(expectedTV2, tokenV2.tV2());
+
+        // create TokenV3 and update proxy
+        TokenV3 tokenV3Impl = new TokenV3();
+        proxyAdmin.upgrade(ITransparentUpgradeableProxy(address(tokenProxy)), address(tokenV3Impl));
+        TokenV3 tokenV3 = TokenV3(address(tokenProxy));
+
+        // init TokenV3
+        tokenV3.initV3();
+
+        // assert storage
+        assertEq(expectedA, uint256(loadSlot(0))); // a, storage preserved
+        assertEq(expectedB, uint256(loadSlot(1))); // b, storage preserved from V2
+
+        uint256 expectedC = 4;
+        assertEq(expectedC, uint256(loadSlot(2)));
+        assertEq(expectedC, tokenV3.c());
+
+        for (uint256 i = 3; i < 50; i++) {
+            // note: gap has one less slot due to `C.c`
+            assertEq(0, uint256(loadSlot(i))); // empty gap
+        }
+
+        assertEq(expectedTV2, uint256(loadSlot(51))); // tV2, past the __gap
+        assertEq(expectedTV2, tokenV3.tV2());
+
+        uint256 expectedTV3 = 5;
+        assertEq(expectedTV3, uint256(loadSlot(52))); // tV3
+        assertEq(expectedTV3, tokenV3.tV3());
+    }
+}
+
+contract A {
+    uint256 public a;
+}
+
+contract B {
+    uint256 public b;
+}
+
+contract C {
+    uint256 public c;
+}
+
+/*
+* Storage:
+* Slot 0: A.a
+* Slot 1: TokenV1.tV1_unused
+*/
+contract TokenV1 is A {
+    uint256 public tV1_unused; // mimics encumberances, which has currently never been used
+
+    function init() public {
+        a = 1;
+    }
+}
+
+/*
+* Storage:
+* Slot 0: A.a
+* Slot 1: B.b
+* Slot 2-50: TokenV2.__gap
+* Slot 51: tV2;
+*/
+contract TokenV2 is A, B {
+    // removed tV1_unused
+    uint256[49] private __gap;
+    uint256 public tV2;
+
+    function init() public {
+        a = 1;
+    }
+
+    function initV2() public {
+        b = 2;
+        tV2 = 3;
+    }
+}
+
+/*
+* Storage:
+* Slot 0: A.a
+* Slot 1: B.b
+* Slot 2: C.c
+* Slot 3-50: TokenV2.__gap
+* Slot 51: tV2;
+* Slot 52: tV3;
+*/
+contract TokenV3 is A, B, C {
+    uint256[48] private __gap; // element removed from gap to account for new var `C.c`
+    uint256 public tV2;
+    uint256 public tV3;
+
+    function init() public {
+        a = 1;
+    }
+
+    function initV2() public {
+        b = 2;
+        tV2 = 3;
+    }
+
+    function initV3() public {
+        c = 4;
+        tV3 = 5;
+    }
+}

--- a/test/v2/ExampleTokenUpgradeStorageLayoutTests.t.sol
+++ b/test/v2/ExampleTokenUpgradeStorageLayoutTests.t.sol
@@ -2,10 +2,10 @@ pragma solidity ^0.8.28;
 
 import "forge-std/StdUtils.sol";
 import {Test} from "forge-std/Test.sol";
-import {console} from "forge-std/console.sol";
+import "test/TokenTestBase.t.sol";
 
-import "openzeppelin-contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "openzeppelin-contracts/proxy/transparent/ProxyAdmin.sol";
+import "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
 
 /*
 * This test shows that we can safely upgrade from SuperstateTokenV1 to SuperstateTokenV2
@@ -14,7 +14,7 @@ import "openzeppelin-contracts/proxy/transparent/ProxyAdmin.sol";
 *   > Add __gap2 at the end of `SuperstateToken`
 *   > Optionally remove `encumberedBalanceOf`, `encumberances` as they have not been used in v1 and thus will not have corrupt storage
 */
-contract ExampleTokenUpgradeStorageLayoutTests is Test {
+contract ExampleTokenUpgradeStorageLayoutTests is TokenTestBase {
     TransparentUpgradeableProxy tokenProxy;
 
     function setUp() public {}
@@ -24,14 +24,12 @@ contract ExampleTokenUpgradeStorageLayoutTests is Test {
     }
 
     function testExampleUpgradeStorageLayout() public {
-        assertEq(true, true);
-        console.log("hi");
-
         // create TokenV1 and proxies
         TokenV1 tokenV1Impl = new TokenV1();
 
-        ProxyAdmin proxyAdmin = new ProxyAdmin();
-        tokenProxy = new TransparentUpgradeableProxy(address(tokenV1Impl), address(proxyAdmin), "");
+        tokenProxy = new TransparentUpgradeableProxy(address(tokenV1Impl), address(this), "");
+        ProxyAdmin proxyAdmin = ProxyAdmin(getAdminAddress(address(tokenProxy)));
+
         TokenV1 tokenV1 = TokenV1(address(tokenProxy));
 
         // init TokenV1
@@ -48,7 +46,7 @@ contract ExampleTokenUpgradeStorageLayoutTests is Test {
 
         // create TokenV2 and update proxy
         TokenV2 tokenV2Impl = new TokenV2();
-        proxyAdmin.upgrade(ITransparentUpgradeableProxy(address(tokenProxy)), address(tokenV2Impl));
+        proxyAdmin.upgradeAndCall(ITransparentUpgradeableProxy(address(tokenProxy)), address(tokenV2Impl), "");
         TokenV2 tokenV2 = TokenV2(address(tokenProxy));
 
         // init TokenV2
@@ -71,7 +69,7 @@ contract ExampleTokenUpgradeStorageLayoutTests is Test {
 
         // create TokenV3 and update proxy
         TokenV3 tokenV3Impl = new TokenV3();
-        proxyAdmin.upgrade(ITransparentUpgradeableProxy(address(tokenProxy)), address(tokenV3Impl));
+        proxyAdmin.upgradeAndCall(ITransparentUpgradeableProxy(address(tokenProxy)), address(tokenV3Impl), "");
         TokenV3 tokenV3 = TokenV3(address(tokenProxy));
 
         // init TokenV3

--- a/test/v2/USTBv2.t.sol
+++ b/test/v2/USTBv2.t.sol
@@ -56,7 +56,9 @@ contract USTBv2Test is SuperstateTokenTestBase {
 
         // Now upgrade to V2
         USTB tokenImplementation = new USTB(address(this), perms);
-        tokenProxyAdmin.upgradeAndCall(ITransparentUpgradeableProxy(address(tokenProxy)), address(tokenImplementation), "");
+        tokenProxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(address(tokenProxy)), address(tokenImplementation), ""
+        );
 
         /*
             At this point, owner() is 0x00 because the upgraded contract has not

--- a/test/v2/USTBv2TokenStorageLayoutTests.t.sol
+++ b/test/v2/USTBv2TokenStorageLayoutTests.t.sol
@@ -1,0 +1,57 @@
+pragma solidity ^0.8.28;
+
+import "forge-std/StdUtils.sol";
+import {Test} from "forge-std/Test.sol";
+import {PausableUpgradeable} from "openzeppelin-contracts-upgradeable/security/PausableUpgradeable.sol";
+
+import "openzeppelin-contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "openzeppelin-contracts/proxy/transparent/ProxyAdmin.sol";
+
+import {SuperstateTokenV1} from "src/v1/SuperstateTokenV1.sol";
+import {ISuperstateToken} from "src/interfaces/ISuperstateToken.sol";
+import {SuperstateToken} from "src/SuperstateToken.sol";
+import {USTBv1} from "src/v1/USTBv1.sol";
+import {USTB} from "src/USTB.sol";
+import {AllowList} from "src/AllowList.sol";
+import "test/AllowListV2.sol";
+import "test/USTBV2.sol";
+import "test/SuperstateTokenStorageLayoutTestBase.t.sol";
+
+contract USTBv2TokenStorageLayoutTests is SuperstateTokenStorageLayoutTestBase {
+    function initializeExpectedTokenVersions() public override {
+        oldTokenVersion = "1";
+        newTokenVersion = "2";
+    }
+
+    function initializeOldToken() public override {
+        USTBv1 oldTokenImplementation = new USTBv1(address(this), perms);
+        tokenProxy = new TransparentUpgradeableProxy(address(oldTokenImplementation), address(proxyAdmin), "");
+
+        // wrap in ABI to support easier calls
+        oldToken = USTBv1(address(tokenProxy));
+
+        oldToken.initialize("Superstate Short Duration US Government Securities Fund", "USTB");
+
+        currentToken = USTBv1(address(tokenProxy));
+    }
+
+    function upgradeAndInitializeNewToken() public override {
+        // Now upgrade to V2
+        USTB newTokenImplementation = new USTB(address(this), perms);
+        proxyAdmin.upgrade(ITransparentUpgradeableProxy(address(tokenProxy)), address(newTokenImplementation));
+
+        /*
+            At this point, owner() is 0x00 because the upgraded contract has not
+            initialized.
+
+            admin() is the same from the prior version of the contract
+        */
+
+        // initialize v2 of the contract, specifically the new authorization
+        // mechanism via owner()
+        newToken = USTB(address(tokenProxy));
+        SuperstateToken(address(newToken)).initializeV2();
+
+        currentToken = newToken;
+    }
+}


### PR DESCRIPTION
Adds `SuperstateTokenStorageLayoutTestBase` which is flexible enough to support all of our future token upgrades with maximal code reuse.

Within `USTBv2TokenStorageLayoutTests` we are calling out a known issue w/ the upgrade from `v1` to `v2` wrt storage of `nonces`, `encumberedBalanceOf`, and `encumbrances`. This is accepted because these features have not been used in our deployed contracts yet. They will work as expected after upgrading.

Also, this PR adds protections for upgrades in the future by adding the following to `v2` of `SuperstateToken`:
- `uint256[500] private __inheritanceGap` - added as the first storage field within `SuperstateToken`, which will allow us to inherit more contracts in the future. This value is quite large to support contracts that have their own large storage gap (which is usually around 50 slots).
-`uint256[100] private __additionalFieldsGap;` - added as the last storage field within `SuperstateToken`, to allow us to add other fields in future upgrades without impacting other contracts that inherit from `SuperstateToken`.