### PR TITLE
Updating nomenclature to beforeFee/afterFee for event emission

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: SUPTB Test CI
+name: USTB Test CI
 
 on:
   - pull_request
@@ -21,8 +21,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
 
       - name: Install Forge Dependencies
         run: forge install

--- a/src/SuperstateToken.sol
+++ b/src/SuperstateToken.sol
@@ -610,8 +610,8 @@ contract SuperstateToken is ISuperstateToken, ERC20Upgradeable, PausableUpgradea
             subscriber: msg.sender,
             to: to,
             stablecoin: stablecoin,
-            stablecoinInAmount: inAmount,
             stablecoinInAmountAfterFee: stablecoinInAmountAfterFee,
+            stablecoinInAmountBeforeFee: inAmount,
             superstateTokenOutAmount: superstateTokenOutAmount
         });
     }

--- a/src/interfaces/ISuperstateToken.sol
+++ b/src/interfaces/ISuperstateToken.sol
@@ -154,12 +154,18 @@ interface ISuperstateToken is IERC20Upgradeable {
     );
 
     /// @dev Event emitted when stablecoins are used to Subscribe to a Superstate fund
+    /// @param subscriber The address of the subscriber
+    /// @param to The address of the recipient
+    /// @param stablecoin The address of the stablecoin used to subscribe
+    /// @param stablecoinInAmountAfterFee The amount of stablecoin used to subscribe, after fees are deducted
+    /// @param stablecoinInAmountBeforeFee The amount of stablecoin used to subscribe, before fees are deducted
+    /// @param superstateTokenOutAmount The amount of Superstate tokens received
     event SubscribeV2(
         address indexed subscriber,
         address indexed to,
         address stablecoin,
-        uint256 stablecoinInAmount,
         uint256 stablecoinInAmountAfterFee,
+        uint256 stablecoinInAmountBeforeFee,
         uint256 superstateTokenOutAmount
     );
 

--- a/test/token/v5/USTBv5.t.sol
+++ b/test/token/v5/USTBv5.t.sol
@@ -111,7 +111,7 @@ contract USTBv5 is USTBv4 {
             subscriber: alice,
             to: USTB_RECEIVER,
             stablecoin: USDC,
-            stablecoinInAmount: usdcAmountIn,
+            stablecoinInAmountBeforeFee: usdcAmountIn,
             stablecoinInAmountAfterFee: usdcAmountIn,
             superstateTokenOutAmount: ustbAmountOut
         });
@@ -141,7 +141,7 @@ contract USTBv5 is USTBv4 {
             subscriber: alice,
             to: USTB_RECEIVER,
             stablecoin: USDC,
-            stablecoinInAmount: usdcAmountIn,
+            stablecoinInAmountBeforeFee: usdcAmountIn,
             stablecoinInAmountAfterFee: usdcAmountIn - usdcAmountFee,
             superstateTokenOutAmount: ustbAmountOut
         });


### PR DESCRIPTION
Updating ustb to follow onchain-redemptions nomenclature. 

See https://github.com/superstateinc/onchain-redemptions/pull/38

